### PR TITLE
Include QR code extension

### DIFF
--- a/.github/workflows/quarto-publish.yml
+++ b/.github/workflows/quarto-publish.yml
@@ -10,15 +10,19 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-        
+
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
         with:
-          # To install LaTeX to build PDF book 
-          tinytex: true 
+          # To install LaTeX to build PDF book
+          tinytex: true
           # uncomment below and fill to pin a version
           version: 1.2.335
-      
+
+      - name: Install Quarto Extensions
+        run:
+          quarto install --no-prompt extension jmbuhr/quarto-qrcode
+
       # add software dependencies here
 
       - name: Publish to GitHub Pages (and render)
@@ -27,4 +31,3 @@ jobs:
           target: gh-pages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # this secret is always available for github actions
-      


### PR DESCRIPTION
The [Quarto QR Code extension](https://github.com/jmbuhr/quarto-qrcode) is quite useful in slides but it needs installing in the GitHub action.

This PR adds such a section and also serves as a template if other extensions are required by users.